### PR TITLE
fix: publish was never succeeding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   skipNpm:
     description: "Skip publishing to npm"
     required: false
-    default: "false"
+    default: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/dist/index.js
+++ b/dist/index.js
@@ -57037,7 +57037,7 @@ async function runPublish({
   let { packages, tool } = await (0, import_get_packages4.getPackages)(cwd);
   let releasedPackages = [];
   let publishPackageRegex = skipNpm ? GITHUB_TAG_REGEX : NPM_TAG_REGEX;
-  let publishedSucceed = skipNpm ?? changesetPublishOutput.stdout.includes(
+  let publishedSucceed = skipNpm || changesetPublishOutput.stdout.includes(
     `published successfully`
   );
   let lines = changesetPublishOutput.stdout.matchAll(publishPackageRegex);

--- a/src/run.ts
+++ b/src/run.ts
@@ -147,7 +147,7 @@ export async function runPublish({
   let releasedPackages: Package[] = [];
 
   let publishPackageRegex = skipNpm ? GITHUB_TAG_REGEX : NPM_TAG_REGEX;
-  let publishedSucceed = skipNpm ? true : changesetPublishOutput.stdout.includes(
+  let publishedSucceed = skipNpm || changesetPublishOutput.stdout.includes(
     `published successfully`
   );
   let lines = changesetPublishOutput.stdout.matchAll(publishPackageRegex);

--- a/src/run.ts
+++ b/src/run.ts
@@ -147,7 +147,7 @@ export async function runPublish({
   let releasedPackages: Package[] = [];
 
   let publishPackageRegex = skipNpm ? GITHUB_TAG_REGEX : NPM_TAG_REGEX;
-  let publishedSucceed = skipNpm ?? changesetPublishOutput.stdout.includes(
+  let publishedSucceed = skipNpm ? true : changesetPublishOutput.stdout.includes(
     `published successfully`
   );
   let lines = changesetPublishOutput.stdout.matchAll(publishPackageRegex);


### PR DESCRIPTION
The `skipNpm` tag introduced in #7 made use of [`??`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) while giving a default value to `skipNpm` of `false`, which always evaluates to `false` because the nullish coalescing operator only gives the right-hand value when the left-hand is `undefined` or `null`:

```ts
console.log(undefined ?? "text")
// "text"

console.log(false ?? "whatever")
// false
```

This caused the [release workflow](https://github.com/FuelLabs/fuels-ts/actions/runs/8949426259/job/24583719449#step:9:1) of `fuels-ts` to publish the packages to NPM but not create a release to GitHub.

This affected our last _two_ releases, which we had to remedy with manual procedures.

> [!IMPORTANT]
> The same should have happened to other repos/releases dependent on this action/fork.
>
> Double-checking those will be great.