### PR TITLE
fix: make action compatible with `@changesets/cli@2.27.8`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -57017,7 +57017,7 @@ var createRelease = async (octokit, { pkg, tagName }) => {
   }
 };
 var GITHUB_TAG_REGEX = /New tag:\s+(.+)@(.+)/g;
-var NPM_TAG_REGEX = /"(.+)("\s(at))/g;
+var NPM_TAG_REGEX = /🦋\s+(.+)@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/g;
 async function runPublish({
   script,
   githubToken,

--- a/src/run.ts
+++ b/src/run.ts
@@ -123,7 +123,9 @@ type PublishResult =
 
 
 const GITHUB_TAG_REGEX = /New tag:\s+(.+)@(.+)/g;
-const NPM_TAG_REGEX = /"(.+)("\s(at))/g;
+// 🦋\s+(.+) corresponds to the way changeset formats its logs
+// the part after @ is taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+const NPM_TAG_REGEX = /🦋\s+(.+)@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/g;
 
 export async function runPublish({
   script,


### PR DESCRIPTION
<!--- LINEAR: closes TS-667 -->
- Closes https://github.com/FuelLabs/fuels-ts/issues/3226

A recent dependabot patch bump of the `@changesets/cli` package in https://github.com/FuelLabs/fuels-ts/pull/3173 caused the subsequent release workflow of `fuels` to [silently fail](https://github.com/FuelLabs/fuels-ts/actions/runs/11061528093/job/30734321051#step:10:1) when creating a GitHub release. This happened because the silently failing logic depended on the `published` output of this action to be `true`, but it was `false` even though the publish to the npm registry happened.

Upon inspection, I found the problem to be the PR https://github.com/changesets/changesets/pull/1417 which was released in [`@changesets/cli@2.27.8`](https://github.com/changesets/changesets/releases/tag/%40changesets%2Fcli%402.27.8), which caused the outputted logs to contain coloring escape codes whereas previously they weren't there ([uncolored and successful run](https://github.com/FuelLabs/fuels-ts/actions/runs/10851674269/job/30115958230#step:9:79), [colored and silently failing run](https://github.com/FuelLabs/fuels-ts/actions/runs/11061528093/job/30734321051#step:9:79)). Because the `published` variable's setting depended on parsing of the outputs of the `pnpm changeset` cli run, and these outputs have become intertwined with escape codes, the parsing failed even though the publishing itself was successful.

This PR updates the regex with which the parsing is done, so that now the necessary info is extract from another place in the logs which remained unchanged after the version bump. Previously it was taking the published package names from:
```
🦋  info Publishing "@fuel-ts/abi-coder" at "0.94.6"
🦋  info Publishing "@fuel-ts/abi-typegen" at "0.94.6"
...
```
Now it's taking them from:
```
🦋  success packages published successfully:
🦋  @fuel-ts/abi-coder@0.94.6
🦋  @fuel-ts/abi-typegen@0.94.6
...
```

Thus, this regex is now compatible with both the previous and new version of `@changesets/cli`.